### PR TITLE
sct: rest of parsing and "reserialising"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "approx"
@@ -65,9 +65,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bevy_derive"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa901a443b9ee433823f0d1a4e6db78440ff27572a98e7fa7f2a614bf8d6e475"
+checksum = "57d94761ce947b0a2402fd949fe1e7a5b1535293130ba4cd9893be6295d4680a"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090371a2cd85574989febff6063a21d1fbbc2939e80f00fe075f62aa8e616136"
+checksum = "8bb6ded1ddc124ea214f6a2140e47a78d1fe79b0638dad39419cdeef2e1133f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -88,15 +88,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_ptr"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da2111eefa2000ea8c9dc1beee2eb7283b29b5ef90a29fe43c748df549f84ad"
+checksum = "89fe0b0b919146939481a3a7c38864face2c6d0fd2c73ab3d430dc693ecd9b11"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82af24a68fd8feff476d9672ff34d220d3f45e95ef2f2324e7cb674614d18138"
+checksum = "3ddbca0a39e88eff2c301dc794ee9d73a53f4b08d47b2c9b5a6aac182fae6217"
 dependencies = [
  "assert_type_match",
  "bevy_ptr",
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8369e6e779ab3540f9dcd93d062139f62551b3d2fe1ab451c6ddf74757e22ccd"
+checksum = "d62affb769db17d34ad0b75ff27eca94867e2acc8ea350c5eca97d102bd98709"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2993cac374b3f88cfaf59506c71f8e3e7ad8b4961f4e9864bc76e1c9e1e4400c"
+checksum = "63c2174d43a0de99f863c98a472370047a2bfa7d1e5cec8d9d647fb500905d9d"
 dependencies = [
  "ahash",
  "bevy_utils_proc_macros",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils_proc_macros"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2606f79dfe359a88e2a59bb6cd632cd42e9d4bcd250ac8bc3a4e7657e82f4f39"
+checksum = "94847541f6dd2e28f54a9c2b0e857da5f2631e2201ebc25ce68781cdcb721391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -232,9 +232,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -334,15 +334,15 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
 dependencies = [
  "serde",
  "typeid",
@@ -353,6 +353,12 @@ name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "from-pest"
@@ -405,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f47c611187777bbca61ea7aba780213f5f3441fd36294ab333e96cfa791b65"
+checksum = "3bd1157f0f936bf0cd68dec91e8f7c311afe60295574d62b70d4861a1bfdf2d9"
 dependencies = [
  "approx",
  "num-traits",
@@ -427,15 +433,15 @@ dependencies = [
 
 [[package]]
 name = "geojson"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d728c1df1fbf328d74151efe6cb0586f79ee813346ea981add69bd22c9241b"
+checksum = "e26f3c45b36fccc9cf2805e61d4da6bc4bbd5a3a9589b01afa3a40eff703bd79"
 dependencies = [
  "geo-types",
  "log",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -476,6 +482,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heapless"
@@ -513,9 +524,9 @@ checksum = "347c253b4748a1a28baf94c9ce133b6b166f08573157e05afe718812bc599fcd"
 
 [[package]]
 name = "i_overlay"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06740cd31c1f963823e007d8e6edcd2db634b2856f4f613e3df01737fd852482"
+checksum = "01882ce5ed786bf6e8f5167f171a4026cd129ce17d9ff5cbf1e6749b98628ece"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -542,9 +553,9 @@ checksum = "155181bc97d770181cf9477da51218a19ee92a8e5be642e796661aee2b601139"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -569,16 +580,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.14"
+name = "itertools"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -592,9 +612,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libm"
@@ -604,9 +624,9 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "memchr"
@@ -739,7 +759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
+ "thiserror",
  "ucd-trie",
 ]
 
@@ -859,18 +879,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -958,24 +978,24 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -984,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1022,17 +1042,17 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "spade"
-version = "2.12.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f5ef1f863aca7d1d7dda7ccfc36a0a4279bd6d3c375176e5e0712e25cb4889"
+checksum = "1ece03ff43cd2a9b57ebf776ea5e78bd30b3b4185a619f041079f4109f385034"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "num-traits",
  "robust",
  "smallvec",
@@ -1046,9 +1066,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1057,38 +1077,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
-dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1122,9 +1122,9 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1190,15 +1190,15 @@ dependencies = [
 
 [[package]]
 name = "typeid"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
@@ -1208,9 +1208,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-xid"
@@ -1249,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vatsim-parser"
@@ -1264,6 +1264,7 @@ dependencies = [
  "fs-err",
  "geo",
  "geojson",
+ "itertools 0.14.0",
  "multimap",
  "num-derive",
  "num-traits",
@@ -1276,7 +1277,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
  "uom",
@@ -1302,9 +1303,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1313,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -1327,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1337,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1350,9 +1351,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-time"
@@ -1388,9 +1392,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winnow"
-version = "0.6.22"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ encoding_rs = "0.8.35"
 from-pest = "0.3.3"
 fs-err = "3.1.0"
 geo = { version = "0.29", features = ["use-serde"] }
+itertools = "0.14.0"
 multimap = "0.10.0"
 num-derive = "0.4.2"
 num-traits = "0.2.19"

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
               nativeBuildInputs = with pkgs; [ pkg-config ];
               buildInputs = with pkgs; [
                 rust-bin.stable.latest.default
+                cargo-machete
                 cargo-tarpaulin
                 cargo-watch
                 config.treefmt.build.wrapper

--- a/src/adaptation/colours.rs
+++ b/src/adaptation/colours.rs
@@ -34,6 +34,10 @@ impl Colour {
         ))
     }
 
+    pub fn to_euroscope(&self) -> i32 {
+        i32::from(self.r) + i32::from(self.g) * 256 + i32::from(self.b) * 256 * 256
+    }
+
     fn from_symbology(symbology: &Symbology, key: &(String, String), default: Colour) -> Self {
         symbology
             .items
@@ -55,7 +59,7 @@ struct ColourVisitor;
 static HASH_RGB_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$").unwrap());
 
-impl<'de> Visitor<'de> for ColourVisitor {
+impl Visitor<'_> for ColourVisitor {
     type Value = Colour;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/src/ese.rs
+++ b/src/ese.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use thiserror::Error;
 use tracing::warn;
 
-use crate::{adaptation::maps::active::RunwayIdentifier, DegMinSec, FromDegMinSec};
+use crate::{adaptation::maps::active::RunwayIdentifier, DegMinSec, DegMinSecExt as _};
 
 use super::read_to_string;
 
@@ -357,11 +357,11 @@ fn parse_coordinate_part(pair: Pair<Rule>) -> DegMinSec {
         .next()
         .unwrap()
         .as_str()
-        .parse::<f64>()
+        .parse::<i16>()
         .unwrap()
         * match hemi {
-            "N" | "E" | "n" | "e" => 1.0,
-            "S" | "W" | "s" | "w" => -1.0,
+            "N" | "E" | "n" | "e" => 1,
+            "S" | "W" | "s" | "w" => -1,
             _ => unreachable!("{hemi} is not a hemisphere"),
         };
     let min = coordinate_part.next().unwrap().as_str().parse().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,18 +30,70 @@ fn read_to_string(contents: &[u8]) -> Result<String, io::Error> {
     })
 }
 
-type DegMinSec = (f64, f64, f64);
+// deg: i16, because, i.e. UK uses invalid coordinates for dummy data: S999.00.00.000 E999.00.00.000
+type DegMinSec = (i16, u8, f64);
 
-trait FromDegMinSec {
-    fn from_deg_min_sec(lat: DegMinSec, lng: DegMinSec) -> Self;
+fn decimal_to_dms(decimal: f64, is_latitude: bool) -> (u8, u8, f64, char) {
+    let degrees = decimal as i8;
+    let minutes = (decimal.abs().fract() * 60.0) as u8;
+    let seconds = (decimal.abs() - decimal.abs().floor() - f64::from(minutes) / 60.) * 3600.0;
+
+    let direction = if is_latitude {
+        if degrees >= 0 {
+            'N'
+        } else {
+            'S'
+        }
+    } else if degrees >= 0 {
+        'E'
+    } else {
+        'W'
+    };
+
+    (degrees.unsigned_abs(), minutes, seconds, direction)
 }
 
-impl FromDegMinSec for Coord {
+trait DegMinSecExt {
+    fn from_deg_min_sec(lat: DegMinSec, lng: DegMinSec) -> Self;
+    fn lat_deg_min_sec_fmt(&self) -> String;
+    fn lon_deg_min_sec_fmt(&self) -> String;
+    fn deg_min_sec_fmt(&self) -> String {
+        format!(
+            "{} {}",
+            self.lat_deg_min_sec_fmt(),
+            self.lon_deg_min_sec_fmt()
+        )
+    }
+}
+
+impl DegMinSecExt for Coord {
     fn from_deg_min_sec(lat: DegMinSec, lng: DegMinSec) -> Self {
+        let lat_deg = f64::from(lat.0);
+        let lat_min = f64::from(lat.1);
+        let lng_deg = f64::from(lng.0);
+        let lng_min = f64::from(lng.1);
         Self {
-            y: lat.0 + lat.0.signum() * lat.1 / 60.0 + lat.0.signum() * lat.2 / 3600.0,
-            x: lng.0 + lng.0.signum() * lng.1 / 60.0 + lng.0.signum() * lng.2 / 3600.0,
+            y: lat_deg + lat_deg.signum() * lat_min / 60.0 + lat_deg.signum() * lat.2 / 3600.0,
+            x: lng_deg + lng_deg.signum() * lng_min / 60.0 + lng_deg.signum() * lng.2 / 3600.0,
         }
+    }
+
+    fn lat_deg_min_sec_fmt(&self) -> String {
+        let lat = decimal_to_dms(self.y, true);
+        let deg = lat.0;
+        let carry_rounded_sec = (lat.2 - 60.).abs() < 0.000_001;
+        let min = lat.1 + if carry_rounded_sec { 1 } else { 0 };
+        let sec = if carry_rounded_sec { 0.0 } else { lat.2 };
+        format!("{}{deg:03}.{min:02}.{sec:06.3}", lat.3)
+    }
+
+    fn lon_deg_min_sec_fmt(&self) -> String {
+        let lon = decimal_to_dms(self.x, false);
+        let deg = lon.0;
+        let carry_rounded_sec = (lon.2 - 60.).abs() < 0.000_001;
+        let min = lon.1 + if carry_rounded_sec { 1 } else { 0 };
+        let sec = if carry_rounded_sec { 0.0 } else { lon.2 };
+        format!("{}{deg:03}.{min:02}.{sec:06.3}", lon.3)
     }
 }
 
@@ -105,5 +157,34 @@ where
 {
     fn default() -> Self {
         Self(MultiMap::default())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use geo::Coord;
+
+    use crate::DegMinSecExt as _;
+
+    #[test]
+    fn test_dms_roundtrip() {
+        let lat = (48, 40, 0.);
+        let lng = (10, 58, 0.5);
+        let coord = Coord::from_deg_min_sec(lat, lng);
+        let expected = 48.666_666_666_666_666;
+        assert!(
+            (coord.y - expected).abs() < f64::EPSILON,
+            "left: {:?} not equal right: {:?}",
+            coord.y,
+            expected
+        );
+        let expected = 10.966_805_555_555_556;
+        assert!(
+            (coord.x - expected).abs() < f64::EPSILON,
+            "left: {:?} not equal right: {:?}",
+            coord.x,
+            expected
+        );
+        assert_eq!(coord.deg_min_sec_fmt(), "N048.40.00.000 E010.58.00.500");
     }
 }

--- a/src/pest/sct.pest
+++ b/src/pest/sct.pest
@@ -7,6 +7,11 @@ section = _{
   | fixes_section
   | airport_section
   | runway_section
+  | sid_section
+  | star_section
+  | artcc_high_section
+  | artcc_section
+  | artcc_low_section
   | high_airway_section
   | low_airway_section
   | region_section
@@ -29,10 +34,15 @@ ndb_section = { "[NDB]" ~ NL ~ colour_definition* ~ ((location | broken) ~ NL)* 
 fixes_section = { "[FIXES]" ~ NL ~ colour_definition* ~ ((fix | broken) ~ NL)* ~ colour_definition* }
 airport_section = { "[AIRPORT]" ~ NL ~ colour_definition* ~ (aerodrome ~ NL?)* ~ colour_definition* }
 runway_section = { "[RUNWAY]" ~ NL ~ colour_definition* ~ (runway ~ NL)* ~ colour_definition* }
+sid_section = { "[SID]" ~ NL ~ colour_definition* ~ coloured_lines* ~ colour_definition* }
+star_section = { "[STAR]" ~ NL ~ colour_definition* ~ coloured_lines* ~ colour_definition* }
+artcc_high_section = { "[ARTCC HIGH]" ~ NL ~ colour_definition* ~ coloured_lines* ~ colour_definition* }
+artcc_section = { "[ARTCC]" ~ NL ~ colour_definition* ~ coloured_lines* ~ colour_definition* }
+artcc_low_section = { "[ARTCC LOW]" ~ NL ~ colour_definition* ~ coloured_lines* ~ colour_definition* }
 high_airway_section = { "[HIGH AIRWAY]" ~ NL ~ colour_definition* ~ (airway ~ NL)* ~ colour_definition* }
 low_airway_section = { "[LOW AIRWAY]" ~ NL ~ colour_definition* ~ (airway ~ NL)* ~ colour_definition* }
 region_section = { ("[Regions]" | "[REGIONS]") ~ NL ~ colour_definition* ~ region* ~ colour_definition* }
-geo_section = { "[GEO]" ~ NL ~ colour_definition* ~ geo* ~ colour_definition* }
+geo_section = { "[GEO]" ~ NL ~ colour_definition* ~ coloured_lines* ~ colour_definition* }
 unparsed_section = { (section_header ~ NL ~ line*) }
 
 sector_name = @{ (LETTER | ASCII_DIGIT | "\t" | ' '..'~')+ }
@@ -43,7 +53,7 @@ colour_definition = { "#define" ~ colour_name ~ pos_integer ~ NL }
 colour_name = @{ (ASCII_ALPHANUMERIC | "-" | "_")+ }
 
 fix = { fix_designator ~ sct_coordinate }
-aerodrome = { designator ~ (frequency | ".")? ~ sct_coordinate ~ ("A" | "B" | "C" | "D" | "E" | "F" | "G") }
+aerodrome = { designator ~ (frequency | ".")? ~ sct_coordinate ~ ctr_airspace }
 location = { designator ~ frequency ~ sct_coordinate }
 runway = { runway_designator ~ runway_designator ~ pos_integer ~ pos_integer ~ sct_coordinate ~ sct_coordinate ~ designator ~ (!NEWLINE ~ ANY)* }
 airway = { fix_designator ~ (sct_coordinate | airway_fix) ~ (sct_coordinate | airway_fix) }
@@ -52,9 +62,11 @@ broken = @{ !("[" | "#") ~ (!NL ~ ANY)* }
 
 region = { "REGIONNAME"? ~ name ~ NL? ~ colour_name ~ sct_coordinate ~ (NL ~ sct_coordinate)* ~ NL }
 
-geo = { non_coordinate_name ~ geo_line_first ~ (NL ~ geo_line)* ~ NL  }
-geo_line_first = { sct_coordinate ~ sct_coordinate ~ colour_name? }
-geo_line = { (sct_coordinate | airway_fix) ~ (sct_coordinate | airway_fix) ~ colour_name? }
+ctr_airspace = { "A" | "B" | "C" | "D" | "E" | "F" | "G" }
+
+coloured_lines = { non_coordinate_name ~ coloured_line_first ~ (NL ~ coloured_line)* ~ NL  }
+coloured_line_first = { sct_coordinate ~ sct_coordinate ~ colour_name? }
+coloured_line = { (sct_coordinate | airway_fix) ~ (sct_coordinate | airway_fix) ~ colour_name? }
 
 airway_fix = { designator ~ designator }
 sct_coordinate = { sct_coord_part ~ sct_coord_part }

--- a/src/sct.rs
+++ b/src/sct.rs
@@ -1,7 +1,9 @@
-use std::collections::HashMap;
+use std::fmt::Formatter;
 use std::io;
+use std::{collections::HashMap, fmt::Display};
 
 use geo::Coord;
+use itertools::Itertools as _;
 use pest::{iterators::Pair, Parser};
 use pest_derive::Parser;
 use serde::Serialize;
@@ -13,7 +15,7 @@ use crate::{
         colours::Colour,
         locations::{Fix, Runway, NDB, VOR},
     },
-    DegMinSec, FromDegMinSec, Location,
+    DegMinSec, DegMinSecExt, Location,
 };
 
 use super::read_to_string;
@@ -35,6 +37,7 @@ pub enum SctError {
 pub struct Airport {
     pub designator: String,
     pub coordinate: Coord,
+    pub ctr_airspace: String,
 }
 
 #[derive(Debug, Serialize, PartialEq)]
@@ -64,6 +67,24 @@ pub struct Geo {
     pub lines: Vec<Line>,
 }
 
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct Sid {
+    pub name: String,
+    pub lines: Vec<Line>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct Star {
+    pub name: String,
+    pub lines: Vec<Line>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct Artcc {
+    pub name: String,
+    pub lines: Vec<Line>,
+}
+
 // TODO ARTCC, SID, STAR, AIRWAY
 #[derive(Debug, Serialize, PartialEq)]
 pub struct Sct {
@@ -74,6 +95,11 @@ pub struct Sct {
     pub ndbs: Vec<NDB>,
     pub vors: Vec<VOR>,
     pub runways: Vec<Runway>,
+    pub sids: Vec<Sid>,
+    pub stars: Vec<Star>,
+    pub artccs_high: Vec<Artcc>,
+    pub artccs: Vec<Artcc>,
+    pub artccs_low: Vec<Artcc>,
     pub high_airways: Vec<Airway>,
     pub low_airways: Vec<Airway>,
     pub regions: Vec<Region>,
@@ -92,6 +118,330 @@ pub struct SctInfo {
     pub scale_factor: f64,
 }
 
+impl Display for SctInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "[INFO]")?;
+        writeln!(f, "{}", self.name)?;
+        writeln!(f, "{}", self.default_callsign)?;
+        writeln!(f, "{}", self.default_airport)?;
+        writeln!(f, "{}", self.centre_point.lat_deg_min_sec_fmt())?;
+        writeln!(f, "{}", self.centre_point.lon_deg_min_sec_fmt())?;
+        writeln!(f, "{}", self.miles_per_deg_lat)?;
+        writeln!(f, "{}", self.miles_per_deg_lng)?;
+        writeln!(f, "{}", self.magnetic_variation)?;
+        writeln!(f, "{}", self.scale_factor)
+    }
+}
+trait ToEuroscope {
+    fn to_euroscope(&self) -> String;
+}
+impl ToEuroscope for Vec<VOR> {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "[VOR]\n{}\n",
+            self.iter()
+                .map(ToEuroscope::to_euroscope)
+                .sorted()
+                .join("\n")
+        )
+    }
+}
+impl ToEuroscope for VOR {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "{:<4} {} {}",
+            self.designator,
+            self.frequency,
+            self.coordinate.deg_min_sec_fmt(),
+        )
+    }
+}
+impl ToEuroscope for Vec<NDB> {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "[NDB]\n{}\n",
+            self.iter()
+                .map(ToEuroscope::to_euroscope)
+                .sorted()
+                .join("\n")
+        )
+    }
+}
+impl ToEuroscope for NDB {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "{:<4} {} {}",
+            self.designator,
+            self.frequency,
+            self.coordinate.deg_min_sec_fmt(),
+        )
+    }
+}
+impl ToEuroscope for Vec<Fix> {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "[FIXES]\n{}\n",
+            self.iter()
+                .map(ToEuroscope::to_euroscope)
+                .sorted()
+                .join("\n")
+        )
+    }
+}
+impl ToEuroscope for Fix {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "{:<5} {}",
+            self.designator,
+            self.coordinate.deg_min_sec_fmt()
+        )
+    }
+}
+impl ToEuroscope for Vec<Airport> {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "[AIRPORT]\n{}\n",
+            self.iter()
+                .map(ToEuroscope::to_euroscope)
+                .sorted()
+                .join("\n")
+        )
+    }
+}
+impl ToEuroscope for Airport {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "{} 000.000 {} {}",
+            self.designator,
+            self.coordinate.deg_min_sec_fmt(),
+            self.ctr_airspace
+        )
+    }
+}
+impl ToEuroscope for Vec<Runway> {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "[RUNWAY]\n{}\n",
+            self.iter()
+                .sorted_by_key(|rwy| &rwy.aerodrome)
+                .map(ToEuroscope::to_euroscope)
+                .join("\n")
+        )
+    }
+}
+impl ToEuroscope for Runway {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "{:<3} {:<3} {:03} {:03} {} {} {}",
+            self.designators.0,
+            self.designators.1,
+            self.headings.0,
+            self.headings.1,
+            self.location.0.deg_min_sec_fmt(),
+            self.location.1.deg_min_sec_fmt(),
+            self.aerodrome
+        )
+    }
+}
+
+impl ToEuroscope for Location {
+    fn to_euroscope(&self) -> String {
+        match self {
+            Location::Fix(fix) => format!("{fix} {fix}"),
+            Location::Coordinate(c) => c.deg_min_sec_fmt(),
+        }
+    }
+}
+impl ToEuroscope for Line {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "{} {}{}",
+            self.start.to_euroscope(),
+            self.end.to_euroscope(),
+            self.colour
+                .as_ref()
+                .map_or(String::new(), |c| format!(" {c}"))
+        )
+    }
+}
+impl ToEuroscope for Vec<Geo> {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "[GEO]\n{}\n",
+            self.iter()
+                .sorted_by_key(|geo| &geo.name)
+                .map(ToEuroscope::to_euroscope)
+                .join("\n\n")
+        )
+    }
+}
+impl ToEuroscope for Geo {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "{:<40} {}{}",
+            self.name,
+            self.lines
+                .first()
+                .map_or(String::new(), ToEuroscope::to_euroscope),
+            (self.lines.len() > 1)
+                .then_some(
+                    self.lines
+                        .iter()
+                        .skip(1)
+                        .map(|l| format!("\n{:<40} {}", "", l.to_euroscope()))
+                        .join("")
+                )
+                .unwrap_or_else(String::new)
+        )
+    }
+}
+impl ToEuroscope for Vec<Region> {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "[REGIONS]\n{}\n",
+            self.iter()
+                .sorted_by_key(|region| &region.name)
+                .map(ToEuroscope::to_euroscope)
+                .join("\n")
+        )
+    }
+}
+impl ToEuroscope for Region {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "REGIONNAME {}\n{:<26} {}{}",
+            self.name,
+            self.colour_name,
+            self.polygon
+                .first()
+                .map_or(String::new(), DegMinSecExt::deg_min_sec_fmt),
+            (self.polygon.len() > 1)
+                .then_some(
+                    self.polygon
+                        .iter()
+                        .skip(1)
+                        .map(|c| format!("\n{:<26} {}", "", c.deg_min_sec_fmt()))
+                        .join("")
+                )
+                .unwrap_or_else(String::new)
+        )
+    }
+}
+impl ToEuroscope for Vec<Airway> {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "{}\n",
+            self.iter()
+                .sorted_by_key(|airway| &airway.designator)
+                .map(ToEuroscope::to_euroscope)
+                .join("\n")
+        )
+    }
+}
+impl ToEuroscope for Airway {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "{:<10} {} {}",
+            self.designator,
+            self.start.to_euroscope(),
+            self.end.to_euroscope()
+        )
+    }
+}
+impl ToEuroscope for Vec<Sid> {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "[SID]\n{}\n",
+            self.iter()
+                .sorted_by_key(|geo| &geo.name)
+                .map(ToEuroscope::to_euroscope)
+                .join("\n\n")
+        )
+    }
+}
+impl ToEuroscope for Sid {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "{:<40} {}{}",
+            self.name,
+            self.lines
+                .first()
+                .map_or(String::new(), ToEuroscope::to_euroscope),
+            (self.lines.len() > 1)
+                .then_some(
+                    self.lines
+                        .iter()
+                        .skip(1)
+                        .map(|l| format!("\n{:<40} {}", "", l.to_euroscope()))
+                        .join("")
+                )
+                .unwrap_or_else(String::new)
+        )
+    }
+}
+impl ToEuroscope for Vec<Star> {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "[STAR]\n{}\n",
+            self.iter()
+                .sorted_by_key(|geo| &geo.name)
+                .map(ToEuroscope::to_euroscope)
+                .join("\n\n")
+        )
+    }
+}
+impl ToEuroscope for Star {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "{:<40} {}{}",
+            self.name,
+            self.lines
+                .first()
+                .map_or(String::new(), ToEuroscope::to_euroscope),
+            (self.lines.len() > 1)
+                .then_some(
+                    self.lines
+                        .iter()
+                        .skip(1)
+                        .map(|l| format!("\n{:<40} {}", "", l.to_euroscope()))
+                        .join("")
+                )
+                .unwrap_or_else(String::new)
+        )
+    }
+}
+impl ToEuroscope for Vec<Artcc> {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "{}\n",
+            self.iter()
+                .sorted_by_key(|geo| &geo.name)
+                .map(ToEuroscope::to_euroscope)
+                .join("\n\n")
+        )
+    }
+}
+impl ToEuroscope for Artcc {
+    fn to_euroscope(&self) -> String {
+        format!(
+            "{:<40} {}{}",
+            self.name,
+            self.lines
+                .first()
+                .map_or(String::new(), ToEuroscope::to_euroscope),
+            (self.lines.len() > 1)
+                .then_some(
+                    self.lines
+                        .iter()
+                        .skip(1)
+                        .map(|l| format!("\n{:<40} {}", "", l.to_euroscope()))
+                        .join("")
+                )
+                .unwrap_or_else(String::new)
+        )
+    }
+}
+
 pub type SctResult = Result<Sct, SctError>;
 
 #[derive(Debug)]
@@ -104,6 +454,11 @@ enum Section {
     NDBs(Vec<NDB>),
     VORs(Vec<VOR>),
     Runways(Vec<Runway>),
+    Sid(Vec<Sid>),
+    Star(Vec<Star>),
+    ArtccHigh(Vec<Artcc>),
+    Artcc(Vec<Artcc>),
+    ArtccLow(Vec<Artcc>),
     Regions(Vec<Region>),
     Geo(Vec<Geo>),
     Unsupported,
@@ -119,6 +474,11 @@ enum SectionName {
     NDBs,
     VORs,
     Runways,
+    Sid,
+    Star,
+    ArtccHigh,
+    Artcc,
+    ArtccLow,
     Regions,
     Geo,
     Unsupported,
@@ -127,15 +487,14 @@ enum SectionName {
 fn parse_coordinate_part(pair: Pair<Rule>) -> DegMinSec {
     let mut coordinate_part = pair.into_inner();
     let hemi = coordinate_part.next().unwrap().as_str();
-    let degrees = coordinate_part
-        .next()
-        .unwrap()
-        .as_str()
-        .parse::<f64>()
+    let degrees_str = coordinate_part.next().unwrap().as_str();
+    let degrees = degrees_str
+        .parse::<i16>()
+        .inspect_err(|e| warn!("Could not parse coordinate, {e}: {degrees_str}"))
         .unwrap()
         * match hemi {
-            "N" | "n" | "E" | "e" => 1.0,
-            "S" | "s" | "W" | "w" => -1.0,
+            "N" | "n" | "E" | "e" => 1,
+            "S" | "s" | "W" | "w" => -1,
             _ => unreachable!("{hemi} is not a hemisphere"),
         };
     let min = coordinate_part.next().unwrap().as_str().parse().unwrap();
@@ -159,10 +518,12 @@ fn parse_airport(pair: Pair<Rule>) -> Airport {
             .find(|pair| matches!(pair.as_rule(), Rule::sct_coordinate))
             .unwrap(),
     );
+    let ctr_airspace = location.next().unwrap().as_str().to_string();
 
     Airport {
         designator,
         coordinate,
+        ctr_airspace,
     }
 }
 
@@ -245,7 +606,7 @@ fn parse_line(pair: Pair<Rule>) -> Option<Line> {
     let (start, end) = if let (Some(start), Some(end)) = (line.next(), line.next()) {
         (parse_location(start), parse_location(end))
     } else {
-        warn!("broken airway (initial parse): {line:?}");
+        warn!("broken coloured line (initial parse): {line:?}");
         return None;
     };
     let colour = line.next().map(|pair| pair.as_str().to_string());
@@ -259,6 +620,30 @@ fn parse_geo(pair: Pair<Rule>) -> Geo {
     let lines = geo.filter_map(parse_line).collect();
 
     Geo { name, lines }
+}
+
+fn parse_sid(pair: Pair<Rule>) -> Sid {
+    let mut sid = pair.into_inner();
+    let name = sid.next().unwrap().as_str().to_string();
+    let lines = sid.filter_map(parse_line).collect();
+
+    Sid { name, lines }
+}
+
+fn parse_star(pair: Pair<Rule>) -> Star {
+    let mut star = pair.into_inner();
+    let name = star.next().unwrap().as_str().to_string();
+    let lines = star.filter_map(parse_line).collect();
+
+    Star { name, lines }
+}
+
+fn parse_artcc(pair: Pair<Rule>) -> Artcc {
+    let mut artcc = pair.into_inner();
+    let name = artcc.next().unwrap().as_str().to_string();
+    let lines = artcc.filter_map(parse_line).collect();
+
+    Artcc { name, lines }
 }
 
 fn parse_vor(pair: Pair<Rule>) -> VOR {
@@ -413,7 +798,6 @@ fn parse_independent_section(
                     .collect(),
             ),
         ),
-
         Rule::runway_section => (
             SectionName::Runways,
             Section::Runways(
@@ -424,6 +808,81 @@ fn parse_independent_section(
                             None
                         } else {
                             Some(parse_runway(pair))
+                        }
+                    })
+                    .collect(),
+            ),
+        ),
+        Rule::sid_section => (
+            SectionName::Sid,
+            Section::Sid(
+                pair.into_inner()
+                    .filter_map(|pair| {
+                        if let Rule::colour_definition = pair.as_rule() {
+                            store_colour(colours, pair);
+                            None
+                        } else {
+                            Some(parse_sid(pair))
+                        }
+                    })
+                    .collect(),
+            ),
+        ),
+        Rule::star_section => (
+            SectionName::Star,
+            Section::Star(
+                pair.into_inner()
+                    .filter_map(|pair| {
+                        if let Rule::colour_definition = pair.as_rule() {
+                            store_colour(colours, pair);
+                            None
+                        } else {
+                            Some(parse_star(pair))
+                        }
+                    })
+                    .collect(),
+            ),
+        ),
+        Rule::artcc_high_section => (
+            SectionName::ArtccHigh,
+            Section::ArtccHigh(
+                pair.into_inner()
+                    .filter_map(|pair| {
+                        if let Rule::colour_definition = pair.as_rule() {
+                            store_colour(colours, pair);
+                            None
+                        } else {
+                            Some(parse_artcc(pair))
+                        }
+                    })
+                    .collect(),
+            ),
+        ),
+        Rule::artcc_section => (
+            SectionName::Artcc,
+            Section::Artcc(
+                pair.into_inner()
+                    .filter_map(|pair| {
+                        if let Rule::colour_definition = pair.as_rule() {
+                            store_colour(colours, pair);
+                            None
+                        } else {
+                            Some(parse_artcc(pair))
+                        }
+                    })
+                    .collect(),
+            ),
+        ),
+        Rule::artcc_low_section => (
+            SectionName::ArtccLow,
+            Section::ArtccLow(
+                pair.into_inner()
+                    .filter_map(|pair| {
+                        if let Rule::colour_definition = pair.as_rule() {
+                            store_colour(colours, pair);
+                            None
+                        } else {
+                            Some(parse_artcc(pair))
                         }
                     })
                     .collect(),
@@ -542,6 +1001,26 @@ impl Sct {
             Some((_, Section::Runways(runways))) => runways,
             _ => vec![],
         };
+        let sids = match sections.remove_entry(&SectionName::Sid) {
+            Some((_, Section::Sid(sids))) => sids,
+            _ => vec![],
+        };
+        let stars = match sections.remove_entry(&SectionName::Star) {
+            Some((_, Section::Star(stars))) => stars,
+            _ => vec![],
+        };
+        let artccs_high = match sections.remove_entry(&SectionName::ArtccHigh) {
+            Some((_, Section::ArtccHigh(artccs))) => artccs,
+            _ => vec![],
+        };
+        let artccs = match sections.remove_entry(&SectionName::Artcc) {
+            Some((_, Section::Artcc(artccs))) => artccs,
+            _ => vec![],
+        };
+        let artccs_low = match sections.remove_entry(&SectionName::ArtccLow) {
+            Some((_, Section::ArtccLow(artccs))) => artccs,
+            _ => vec![],
+        };
         let high_airways = match sections.remove_entry(&SectionName::HighAirway) {
             Some((_, Section::HighAirways(high_airways))) => high_airways,
             _ => vec![],
@@ -567,6 +1046,11 @@ impl Sct {
             ndbs,
             vors,
             runways,
+            sids,
+            stars,
+            artccs_high,
+            artccs,
+            artccs_low,
             high_airways,
             low_airways,
             regions,
@@ -574,6 +1058,34 @@ impl Sct {
         };
 
         Ok(sct)
+    }
+}
+impl Display for Sct {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{}", self.info)?;
+        writeln!(
+            f,
+            "{}\n",
+            self.colours
+                .iter()
+                .map(|(name, c)| format!("#define {name}\t{}", c.to_euroscope()))
+                .sorted()
+                .join("\n")
+        )?;
+        writeln!(f, "{}", self.vors.to_euroscope())?;
+        writeln!(f, "{}", self.ndbs.to_euroscope())?;
+        writeln!(f, "{}", self.fixes.to_euroscope())?;
+        writeln!(f, "{}", self.airports.to_euroscope())?;
+        writeln!(f, "{}", self.runways.to_euroscope())?;
+        writeln!(f, "{}", self.sids.to_euroscope())?;
+        writeln!(f, "{}", self.stars.to_euroscope())?;
+        writeln!(f, "[ARTCC HIGH]\n{}", self.artccs_high.to_euroscope())?;
+        writeln!(f, "[ARTCC]\n{}", self.artccs.to_euroscope())?;
+        writeln!(f, "[ARTCC LOW]\n{}", self.artccs_low.to_euroscope())?;
+        writeln!(f, "{}", self.geo.to_euroscope())?;
+        writeln!(f, "{}", self.regions.to_euroscope())?;
+        writeln!(f, "[HIGH AIRWAY]\n{}", self.high_airways.to_euroscope())?;
+        write!(f, "[LOW AIRWAY]\n{}", self.low_airways.to_euroscope())
     }
 }
 
@@ -589,7 +1101,7 @@ mod test {
             colours::Colour,
             locations::{Fix, NDB, VOR},
         },
-        sct::{Airport, Airway, Geo, Line, Region, Runway, Sct, SctInfo},
+        sct::{Airport, Airway, Artcc, Geo, Line, Region, Runway, Sct, SctInfo, Sid, Star},
         Location,
     };
 
@@ -867,21 +1379,24 @@ A5         RTT RTT NUB NUB
                     coordinate: Coord {
                         y: 48.353_782_777_777_78,
                         x: 11.786_085_833_333_333
-                    }
+                    },
+                    ctr_airspace: "D".to_string()
                 },
                 Airport {
                     designator: "EDNX".to_string(),
                     coordinate: Coord {
                         y: 48.238_999_722_222_225,
                         x: 11.559_166_944_444_446
-                    }
+                    },
+                    ctr_airspace: "D".to_string()
                 },
                 Airport {
                     designator: "LIPB".to_string(),
                     coordinate: Coord {
                         y: 46.460_277_777_777_78,
                         x: 11.326_388_888_888_89
-                    }
+                    },
+                    ctr_airspace: "D".to_string()
                 }
             ]
         );
@@ -1001,6 +1516,793 @@ A5         RTT RTT NUB NUB
                         }
                     ),
                     aerodrome: "EGAC".to_string()
+                }
+            ]
+        );
+        assert_eq!(
+            sct.as_ref().unwrap().sids,
+            vec![
+                Sid {
+                    name: "EDDM SID 26L BIBAGxS".to_string(),
+                    lines: vec![
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.747_073_611_111_11,
+                                y: 48.340_365_277_777_78
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.709_430_833_333_332,
+                                y: 48.337_668_888_888_89
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.709_430_833_333_332,
+                                y: 48.337_668_888_888_89
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.708_005_833_333_333,
+                                y: 48.287_568_888_888_885
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.708_005_833_333_333,
+                                y: 48.287_568_888_888_885
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.816_535_833_333_335,
+                                y: 48.180_393_888_888_89
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.816_535_833_333_335,
+                                y: 48.180_393_888_888_89
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 12.565_505_833_333_335,
+                                y: 48.231_907_777_777_78
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 12.565_505_833_333_335,
+                                y: 48.231_907_777_777_78
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 12.749_780_833_333_332,
+                                y: 48.39705
+                            }),
+                            colour: None
+                        }
+                    ]
+                },
+                Sid {
+                    name: "EDDN SID 28 BOLSIxG".to_string(),
+                    lines: vec![
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.056_529_722_222_223,
+                                y: 49.500_809_444_444_44
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.92835,
+                                y: 49.513_316_944_444_45
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.92835,
+                                y: 49.513_316_944_444_45
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.762_560_833_333_334,
+                                y: 49.462_324_722_222_23
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.762_560_833_333_334,
+                                y: 49.462_324_722_222_23
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.758_507_777_777_778,
+                                y: 49.231_821_944_444_45
+                            }),
+                            colour: None
+                        }
+                    ]
+                }
+            ]
+        );
+        assert_eq!(
+            sct.as_ref().unwrap().stars,
+            vec![
+                Star {
+                    name: "EDDM TRAN RNP26R LANDU26".to_string(),
+                    lines: vec![
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 12.273_927_777_777_779,
+                                y: 48.596_360_833_333_335
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.501_535_833_333_334,
+                                y: 48.537_916_944_444_44
+                            }),
+                            colour: Some("colour_APP".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.501_535_833_333_334,
+                                y: 48.537_916_944_444_44
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.521_091_944_444_445,
+                                y: 48.428_905_833_333_33
+                            }),
+                            colour: Some("colour_APP".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.521_091_944_444_445,
+                                y: 48.428_905_833_333_33
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 12.378_446_944_444_445,
+                                y: 48.493_421_944_444_44
+                            }),
+                            colour: Some("colour_APP".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 12.378_446_944_444_445,
+                                y: 48.493_421_944_444_44
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 12.627_486_666_666_668,
+                                y: 48.513_155_833_333_336
+                            }),
+                            colour: Some("colour_APP".to_string())
+                        }
+                    ]
+                },
+                Star {
+                    name: "EDDN TRAN ILS10 DN430".to_string(),
+                    lines: vec![
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.509_271_944_444_444,
+                                y: 49.553_135_833_333_33
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.610_596_944_444_444,
+                                y: 49.543_657_777_777_774
+                            }),
+                            colour: Some("colour_APP".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.610_596_944_444_444,
+                                y: 49.543_657_777_777_774
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.711_855_833_333_333,
+                                y: 49.534_091_944_444_44
+                            }),
+                            colour: Some("colour_APP".to_string())
+                        }
+                    ]
+                },
+                Star {
+                    name: "EDQD STAR ALL LONLIxZ".to_string(),
+                    lines: vec![Line {
+                        start: Location::Coordinate(Coord {
+                            x: 11.226_385_833_333_334,
+                            y: 50.074_738_888_888_895
+                        }),
+                        end: Location::Coordinate(Coord {
+                            x: 11.407_927_777_777_779,
+                            y: 49.897_449_722_222_22
+                        }),
+                        colour: None
+                    }]
+                }
+            ]
+        );
+        assert_eq!(
+            sct.as_ref().unwrap().artccs_high,
+            vec![
+                Artcc {
+                    name: "EDJA_ILR_APP".to_string(),
+                    lines: vec![
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 9.570_833_333_333_333,
+                                y: 48.174_444_444_444_44
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 9.923_611_111_111_11,
+                                y: 48.302_499_999_999_995
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 9.570_833_333_333_333,
+                                y: 48.174_444_444_444_44
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 9.55,
+                                y: 48.166_666_666_666_664
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.843_888_888_888_89,
+                                y: 47.983_055_555_555_56
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.428_333_333_333_333,
+                                y: 48.236_666_666_666_665
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.428_333_333_333_333,
+                                y: 48.236_666_666_666_665
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 9.923_611_111_111_11,
+                                y: 48.302_499_999_999_995
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.843_888_888_888_89,
+                                y: 47.983_055_555_555_56
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.466_666_666_666_667,
+                                y: 47.8675
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.466_666_666_666_667,
+                                y: 47.8675
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.383_333_333_333_333,
+                                y: 47.841_666_666_666_67
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.383_333_333_333_333,
+                                y: 47.841_666_666_666_67
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 9.9725,
+                                y: 47.818_055_555_555_56
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 9.835_555_555_555_556,
+                                y: 47.898_055_555_555_56
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 9.905_000_000_000_001,
+                                y: 47.815_277_777_777_77
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 9.905_000_000_000_001,
+                                y: 47.815_277_777_777_77
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 9.9725,
+                                y: 47.818_055_555_555_56
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 9.835_555_555_555_556,
+                                y: 47.898_055_555_555_56
+                            }),
+                            end: Location::Coordinate(Coord { x: 9.55, y: 47.89 }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord { x: 9.55, y: 47.89 }),
+                            end: Location::Coordinate(Coord {
+                                x: 9.55,
+                                y: 47.973_333_333_333_336
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 9.55,
+                                y: 47.973_333_333_333_336
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 9.55,
+                                y: 48.166_666_666_666_664
+                            }),
+                            colour: None
+                        }
+                    ]
+                },
+                Artcc {
+                    name: "Release line EDMM ARBAX Window".to_string(),
+                    lines: vec![
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 12.872_777_777_777_777,
+                                y: 49.442_499_999_999_995
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 13.006_666_666_666_666,
+                                y: 49.588_333_333_333_34
+                            }),
+                            colour: Some("colour_Releaseline".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 13.006_666_666_666_666,
+                                y: 49.588_333_333_333_34
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 13.286_944_444_444_444,
+                                y: 49.462_500_000_000_006
+                            }),
+                            colour: Some("colour_Releaseline".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 13.286_944_444_444_444,
+                                y: 49.462_500_000_000_006
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 13.220_555_555_555_556,
+                                y: 49.211_666_666_666_666
+                            }),
+                            colour: Some("colour_Releaseline".to_string())
+                        }
+                    ]
+                }
+            ]
+        );
+        assert_eq!(
+            sct.as_ref().unwrap().artccs,
+            vec![
+                Artcc {
+                    name: "EDMM_ALB_CTR".to_string(),
+                    lines: vec![
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.1325,
+                                y: 49.138_055_555_555_55
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.966_666_666_666_667,
+                                y: 49.166_666_666_666_664
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.794_166_666_666_667,
+                                y: 48.6675
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.966_666_666_666_667,
+                                y: 49.166_666_666_666_664
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.794_166_666_666_667,
+                                y: 48.6675
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.511_666_666_666_667,
+                                y: 48.667_777_777_777_77
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.511_666_666_666_667,
+                                y: 48.667_777_777_777_77
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.320_833_333_333_333,
+                                y: 48.667_777_777_777_77
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.320_833_333_333_333,
+                                y: 48.667_777_777_777_77
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.673_611_111_111_11,
+                                y: 49.119_444_444_444_45
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.673_611_111_111_11,
+                                y: 49.119_444_444_444_45
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.1325,
+                                y: 49.138_055_555_555_55
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.673_611_111_111_11,
+                                y: 49.119_444_444_444_45
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.587_777_777_777_779,
+                                y: 49.178_611_111_111_11
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.818_888_888_888_889,
+                                y: 49.434_444_444_444_44
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.966_666_666_666_667,
+                                y: 49.441_666_666_666_66
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.587_777_777_777_779,
+                                y: 49.178_611_111_111_11
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.966_666_666_666_667,
+                                y: 49.441_666_666_666_66
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.966_666_666_666_667,
+                                y: 49.441_666_666_666_66
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.765_555_555_555_556,
+                                y: 49.654_722_222_222_22
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.587_777_777_777_779,
+                                y: 49.178_611_111_111_11
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.458_333_333_333_332,
+                                y: 49.283_333_333_333_33
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.458_333_333_333_332,
+                                y: 49.283_333_333_333_33
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.356_111_111_111_11,
+                                y: 49.398_333_333_333_33
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.356_111_111_111_11,
+                                y: 49.398_333_333_333_33
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.503_333_333_333_334,
+                                y: 49.511_111_111_111_11
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.5033_333_333_333_34,
+                                y: 49.511_111_111_111_11
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.765_555_555_555_556,
+                                y: 49.654_722_222_222_22
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.966_666_666_666_667,
+                                y: 49.166_666_666_666_664
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.818_888_888_888_889,
+                                y: 49.434_444_444_444_44
+                            }),
+                            colour: None
+                        }
+                    ]
+                },
+                Artcc {
+                    name: "EDMM_WLD_CTR".to_string(),
+                    lines: vec![
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.966_666_666_666_667,
+                                y: 48.666_666_666_666_664
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.183_333_333_333_334,
+                                y: 48.669_444_444_444_444
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.183_333_333_333_334,
+                                y: 48.669_444_444_444_444
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.320_833_333_333_333,
+                                y: 48.667_777_777_777_77
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.2575,
+                                y: 49.017_222_222_222_22
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.479_166_666_666_666,
+                                y: 49.111_111_111_111_114
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.479_166_666_666_666,
+                                y: 49.111_111_111_111_114
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.587_777_777_777_779,
+                                y: 49.178_611_111_111_11
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.320_833_333_333_333,
+                                y: 48.667_777_777_777_77
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.673_611_111_111_11,
+                                y: 49.119_444_444_444_45
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.673_611_111_111_11,
+                                y: 49.119_444_444_444_45
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.587_777_777_777_779,
+                                y: 49.178_611_111_111_11
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.904_444_444_444_445,
+                                y: 48.624_444_444_444_44
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.2575,
+                                y: 49.017_222_222_222_22
+                            }),
+                            colour: None
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 10.904_444_444_444_445,
+                                y: 48.624_444_444_444_44
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 10.966_666_666_666_667,
+                                y: 48.666_666_666_666_664
+                            }),
+                            colour: None
+                        }
+                    ]
+                }
+            ]
+        );
+        assert_eq!(
+            sct.as_ref().unwrap().artccs_low,
+            vec![
+                Artcc {
+                    name: "RMZ EDMS".to_string(),
+                    lines: vec![
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 12.392_777_777_777_777,
+                                y: 48.961_111_111_111_116
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 12.660_555_555_555_556,
+                                y: 48.939_444_444_444_44
+                            }),
+                            colour: Some("colour_RMZ".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 12.660_555_555_555_556,
+                                y: 48.939_444_444_444_44
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 12.641_666_666_666_666,
+                                y: 48.840_277_777_777_78
+                            }),
+                            colour: Some("colour_RMZ".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 12.641_666_666_666_666,
+                                y: 48.840_277_777_777_78
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 12.374_444_444_444_444,
+                                y: 48.861_944_444_444_45
+                            }),
+                            colour: Some("colour_RMZ".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 12.374_444_444_444_444,
+                                y: 48.861_944_444_444_45
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 12.392_777_777_777_777,
+                                y: 48.961_111_111_111_116
+                            }),
+                            colour: Some("colour_RMZ".to_string())
+                        }
+                    ]
+                },
+                Artcc {
+                    name: "RMZ EDNX".to_string(),
+                    lines: vec![
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.455_833_333_333_333,
+                                y: 48.274_166_666_666_666
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.534_722_222_222_221,
+                                y: 48.286_666_666_666_66
+                            }),
+                            colour: Some("colour_RMZ".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.534_722_222_222_221,
+                                y: 48.286_666_666_666_66
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.535_833_333_333_333,
+                                y: 48.273_611_111_111_11
+                            }),
+                            colour: Some("colour_RMZ".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.535_833_333_333_333,
+                                y: 48.273_611_111_111_11
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.640_833_333_333_333,
+                                y: 48.281_666_666_666_666
+                            }),
+                            colour: Some("colour_RMZ".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.640_833_333_333_333,
+                                y: 48.281_666_666_666_666
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.673_611_111_111_11,
+                                y: 48.254_722_222_222_22
+                            }),
+                            colour: Some("colour_RMZ".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.673_611_111_111_11,
+                                y: 48.254_722_222_222_22
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.677_777_777_777_777,
+                                y: 48.241_111_111_111_11
+                            }),
+                            colour: Some("colour_RMZ".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.677_777_777_777_777,
+                                y: 48.241_111_111_111_11
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.6625,
+                                y: 48.203_888_888_888_89
+                            }),
+                            colour: Some("colour_RMZ".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.6625,
+                                y: 48.203_888_888_888_89
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.489_444_444_444_443,
+                                y: 48.177_222_222_222_22
+                            }),
+                            colour: Some("colour_RMZ".to_string())
+                        },
+                        Line {
+                            start: Location::Coordinate(Coord {
+                                x: 11.489_444_444_444_443,
+                                y: 48.177_222_222_222_22
+                            }),
+                            end: Location::Coordinate(Coord {
+                                x: 11.455_833_333_333_333,
+                                y: 48.274_166_666_666_666
+                            }),
+                            colour: Some("colour_RMZ".to_string())
+                        }
+                    ]
                 }
             ]
         );
@@ -1300,7 +2602,354 @@ A5         RTT RTT NUB NUB
                 },
             ]
         );
-        // TODO ARTCC, SID, STAR, AIRWAY
+    }
+
+    #[test]
+    fn test_sct_fmt() {
+        let sct_bytes = b"
+;=========================================================================================================================;
+
+[INFO]
+AeroNav M\xfcnchen 2401/1-1 EDMM 20240125
+AERO_NAV
+ZZZZ
+N048.21.13.618
+E011.47.09.909
+60
+39
+-3
+1
+
+#define colour_APP       16711680
+#define colour_AirspaceA  8421376
+#define prohibitcolour 7697781		; 117,117,117	Prohibited areas
+
+[VOR]
+NUB  115.750 N049.30.10.508 E011.02.06.000 ; NUB Comment Test
+OTT  112.300 N048.10.49.418 E011.48.59.529
+
+[NDB]
+MIQ  426.000 N048.34.12.810 E011.35.51.010 ;MIQ Comment Test
+RTT  303.000 N047.25.51.319 E011.56.24.190
+
+[FIXES]
+(FM-C) N049.31.05.999 E008.26.42.000
+ARMUT N049.43.20.999 E012.19.23.998
+GEDSO N047.04.50.001 E011.52.13.000
+INBED N049.23.15.000 E010.56.30.001
+NAXAV N046.27.49.881 E011.19.19.858
+UNKUL N049.08.13.999 E011.27.34.999
+VEMUT N049.48.38.678 E012.27.40.489
+
+[AIRPORT]
+EDDM 000.000 N048.21.13.618 E011.47.09.909 D
+EDNX 000.000 N048.14.20.399 E011.33.33.001 D
+LIPB 000.000 N046.27.37.000 E011.19.35.000 D
+
+[RUNWAY]
+08R 26L 080 260 N048.20.26.408 E011.45.03.661 N048.20.41.269 E011.48.16.610 EDDM
+08L 26R 080 260 N048.21.45.961 E011.46.03.179 N048.22.00.789 E011.49.16.219 EDDM
+07  25  071 251 N048.14.17.710 E011.33.14.090 N048.14.24.388 E011.33.51.998 EDNX
+04 22 037 217 N054.36.43.340 W005.52.47.140 N054.37.29.480 W005.51.51.950 EGAC Belfast/City
+
+[SID]
+EDDM SID 26L BIBAGxS                     N048.20.25.315 E011.44.49.465 N048.20.15.608 E011.42.33.951
+                                         N048.20.15.608 E011.42.33.951 N048.17.15.248 E011.42.28.821
+                                         N048.17.15.248 E011.42.28.821 N048.10.49.418 E011.48.59.529
+                                         N048.10.49.418 E011.48.59.529 N048.13.54.868 E012.33.55.821
+                                         N048.13.54.868 E012.33.55.821 N048.23.49.380 E012.44.59.211
+
+EDDN SID 28 BOLSIxG                      N049.30.02.914 E011.03.23.507 N049.30.47.941 E010.55.42.060
+                                         N049.30.47.941 E010.55.42.060 N049.27.44.369 E010.45.45.219
+                                         N049.27.44.369 E010.45.45.219 N049.13.54.559 E010.45.30.628
+
+[STAR]
+EDDM TRAN RNP26R LANDU26                 N048.35.46.899 E012.16.26.140 N048.32.16.501 E011.30.05.529 colour_APP
+                                         N048.32.16.501 E011.30.05.529 N048.25.44.061 E011.31.15.931 colour_APP
+                                         N048.25.44.061 E011.31.15.931 N048.29.36.319 E012.22.42.409 colour_APP
+                                         N048.29.36.319 E012.22.42.409 N048.30.47.361 E012.37.38.952 colour_APP
+
+EDDN TRAN ILS10 DN430                    N049.33.11.289 E010.30.33.379 N049.32.37.168 E010.36.38.149 colour_APP
+                                         N049.32.37.168 E010.36.38.149 N049.32.02.731 E010.42.42.681 colour_APP
+
+EDQD STAR ALL LONLIxZ                    N050.04.29.060 E011.13.34.989 N049.53.50.819 E011.24.28.540
+
+
+[ARTCC HIGH]
+EDJA_ILR_APP                             N048.10.28.000 E009.34.15.000 N048.18.09.000 E009.55.25.000
+                                         N048.10.28.000 E009.34.15.000 N048.10.00.000 E009.33.00.000
+                                         N047.58.59.000 E010.50.38.000 N048.14.12.000 E010.25.42.000
+                                         N048.14.12.000 E010.25.42.000 N048.18.09.000 E009.55.25.000
+                                         N047.58.59.000 E010.50.38.000 N047.52.03.000 E010.28.00.000
+                                         N047.52.03.000 E010.28.00.000 N047.50.30.000 E010.23.00.000
+                                         N047.50.30.000 E010.23.00.000 N047.49.05.000 E009.58.21.000
+                                         N047.53.53.000 E009.50.08.000 N047.48.55.000 E009.54.18.000
+                                         N047.48.55.000 E009.54.18.000 N047.49.05.000 E009.58.21.000
+                                         N047.53.53.000 E009.50.08.000 N047.53.24.000 E009.33.00.000
+                                         N047.53.24.000 E009.33.00.000 N047.58.24.000 E009.33.00.000
+                                         N047.58.24.000 E009.33.00.000 N048.10.00.000 E009.33.00.000
+
+Release line EDMM ARBAX Window           N049.26.33.000 E012.52.22.000 N049.35.18.000 E013.00.24.000 colour_Releaseline
+                                         N049.35.18.000 E013.00.24.000 N049.27.45.000 E013.17.13.000 colour_Releaseline
+                                         N049.27.45.000 E013.17.13.000 N049.12.42.000 E013.13.14.000 colour_Releaseline
+[ARTCC]
+EDMM_ALB_CTR                             N049.08.17.000 E011.07.57.000 N049.10.00.000 E011.58.00.000
+                                         N048.40.03.000 E011.47.39.000 N049.10.00.000 E011.58.00.000
+                                         N048.40.03.000 E011.47.39.000 N048.40.04.000 E011.30.42.000
+                                         N048.40.04.000 E011.30.42.000 N048.40.04.000 E011.19.15.000
+                                         N048.40.04.000 E011.19.15.000 N049.07.10.000 E010.40.25.000
+                                         N049.07.10.000 E010.40.25.000 N049.08.17.000 E011.07.57.000
+                                         N049.07.10.000 E010.40.25.000 N049.10.43.000 E010.35.16.000
+                                         N049.26.04.000 E011.49.08.000 N049.26.30.000 E010.58.00.000
+                                         N049.10.43.000 E010.35.16.000 N049.26.30.000 E010.58.00.000
+                                         N049.26.30.000 E010.58.00.000 N049.39.17.000 E010.45.56.000
+                                         N049.10.43.000 E010.35.16.000 N049.17.00.000 E010.27.30.000
+                                         N049.17.00.000 E010.27.30.000 N049.23.54.000 E010.21.22.000
+                                         N049.23.54.000 E010.21.22.000 N049.30.40.000 E010.30.12.000
+                                         N049.30.40.000 E010.30.12.000 N049.39.17.000 E010.45.56.000
+                                         N049.10.00.000 E011.58.00.000 N049.26.04.000 E011.49.08.000
+
+EDMM_WLD_CTR                             N048.40.00.000 E010.58.00.000 N048.40.10.000 E011.11.00.000
+                                         N048.40.10.000 E011.11.00.000 N048.40.04.000 E011.19.15.000
+                                         N049.01.02.000 E010.15.27.000 N049.06.40.000 E010.28.45.000
+                                         N049.06.40.000 E010.28.45.000 N049.10.43.000 E010.35.16.000
+                                         N048.40.04.000 E011.19.15.000 N049.07.10.000 E010.40.25.000
+                                         N049.07.10.000 E010.40.25.000 N049.10.43.000 E010.35.16.000
+                                         N048.37.28.000 E010.54.16.000 N049.01.02.000 E010.15.27.000
+                                         N048.37.28.000 E010.54.16.000 N048.40.00.000 E010.58.00.000
+
+
+[ARTCC LOW]
+RMZ EDMS                                 N048.57.40.000 E012.23.34.000 N048.56.22.000 E012.39.38.000 colour_RMZ
+                                         N048.56.22.000 E012.39.38.000 N048.50.25.000 E012.38.30.000 colour_RMZ
+                                         N048.50.25.000 E012.38.30.000 N048.51.43.000 E012.22.28.000 colour_RMZ
+                                         N048.51.43.000 E012.22.28.000 N048.57.40.000 E012.23.34.000 colour_RMZ
+
+RMZ EDNX                                 N048.16.27.000 E011.27.21.000 N048.17.12.000 E011.32.05.000 colour_RMZ
+                                         N048.17.12.000 E011.32.05.000 N048.16.25.000 E011.32.09.000 colour_RMZ
+                                         N048.16.25.000 E011.32.09.000 N048.16.54.000 E011.38.27.000 colour_RMZ
+                                         N048.16.54.000 E011.38.27.000 N048.15.17.000 E011.40.25.000 colour_RMZ
+                                         N048.15.17.000 E011.40.25.000 N048.14.28.000 E011.40.40.000 colour_RMZ
+                                         N048.14.28.000 E011.40.40.000 N048.12.14.000 E011.39.45.000 colour_RMZ
+                                         N048.12.14.000 E011.39.45.000 N048.10.38.000 E011.29.22.000 colour_RMZ
+                                         N048.10.38.000 E011.29.22.000 N048.16.27.000 E011.27.21.000 colour_RMZ
+
+
+[GEO]
+EDDN Groundlayout Holding Points         N049.29.58.736 E011.03.33.028 N049.29.58.942 E011.03.34.353 colour_Stopbar
+                                         N049.29.56.786 E011.03.52.659 N049.29.57.006 E011.03.54.022 colour_Stopbar
+
+EDQC Groundlayout                        N050.15.52.011 E010.59.29.553 N050.15.52.239 E010.59.29.566
+
+EDQC Groundlayout                        N050.15.52.011 E010.59.29.553 N050.15.52.239 E010.59.29.566 colour_Stopbar
+                                         N050.15.39.345 E011.00.04.860 N050.15.39.411 E011.00.05.139 colour_Stopbar
+                                         N050.15.39.345 E011.00.04.860 N050.15.39.411 E011.00.05.139
+                                         RAVSA RAVSA LCE13 LCE13 geoDefault
+HIGHWAYS LOVV                            N048.12.09.100 E016.13.16.700 N048.11.27.100 E016.12.10.100 COLOR_Landmark2
+                                         N050.15.39.345 E011.00.04.860 N050.15.39.411 E011.00.05.139 colour_Stopbar
+[REGIONS]
+REGIONNAME EDDM Groundlayout
+colour_Stopbar              N048.21.53.621 E011.48.32.152
+                           N048.21.54.514 E011.48.32.715
+                           N048.21.54.527 E011.48.32.571
+                           N048.21.53.676 E011.48.32.042
+REGIONNAME EDMO Groundlayout
+colour_HardSurface1         N048.04.25.470 E011.16.20.093
+                           N048.04.24.509 E011.16.21.717
+                           N048.05.20.677 E011.17.38.446
+                           N048.05.21.638 E011.17.36.829
+Surrounding Grass	grass	N51.11.37.165 E02.51.07.153
+ N51.11.38.619 E02.51.08.463
+ N51.11.39.660 E02.51.10.008
+
+[HIGH AIRWAY]
+B73        N054.54.46.000 E018.57.29.998 N055.36.12.999 E019.50.17.901
+B74        N055.12.05.000 E019.38.03.001 N055.36.12.999 E019.50.17.901
+B74        N054.38.16.000 E019.21.20.001 N055.12.05.000 E019.38.03.001
+B75        ARMUT ARMUT VEMUT VEMUT
+B76        ARMUT ARMUT RTT RTT
+
+[LOW AIRWAY]
+A361       N048.56.21.001 E000.57.11.001 N048.47.26.199 E000.31.49.000
+A361       N049.01.42.700 E001.12.50.601 N048.56.21.001 E000.57.11.001
+A4         N048.37.03.248 E017.32.28.201 N048.42.56.998 E017.23.09.999
+A4         N048.17.25.569 E018.03.02.300 N048.37.03.248 E017.32.28.201
+A4         N048.42.56.998 E017.23.09.999 N048.51.11.520 E017.10.04.238
+A5         RTT RTT NUB NUB
+        ";
+        let sct = Sct::parse(sct_bytes).unwrap();
+
+        let sct_generated = sct.to_string();
+        let expected_generated = "[INFO]
+AeroNav München 2401/1-1 EDMM 20240125
+AERO_NAV
+ZZZZ
+N048.21.13.618
+E011.47.09.909
+60
+39
+-3
+1
+
+#define colour_APP\t16711680
+#define colour_AirspaceA\t8421376
+#define prohibitcolour\t7697781
+
+[VOR]
+NUB  115.750 N049.30.10.508 E011.02.06.000
+OTT  112.300 N048.10.49.418 E011.48.59.529
+
+[NDB]
+MIQ  426.000 N048.34.12.810 E011.35.51.010
+RTT  303.000 N047.25.51.319 E011.56.24.190
+
+[FIXES]
+(FM-C) N049.31.05.999 E008.26.42.000
+ARMUT N049.43.20.999 E012.19.23.998
+GEDSO N047.04.50.001 E011.52.13.000
+INBED N049.23.15.000 E010.56.30.001
+NAXAV N046.27.49.881 E011.19.19.858
+UNKUL N049.08.13.999 E011.27.34.999
+VEMUT N049.48.38.678 E012.27.40.489
+
+[AIRPORT]
+EDDM 000.000 N048.21.13.618 E011.47.09.909 D
+EDNX 000.000 N048.14.20.399 E011.33.33.001 D
+LIPB 000.000 N046.27.37.000 E011.19.35.000 D
+
+[RUNWAY]
+08R 26L 080 260 N048.20.26.408 E011.45.03.661 N048.20.41.269 E011.48.16.610 EDDM
+08L 26R 080 260 N048.21.45.961 E011.46.03.179 N048.22.00.789 E011.49.16.219 EDDM
+07  25  071 251 N048.14.17.710 E011.33.14.090 N048.14.24.388 E011.33.51.998 EDNX
+04  22  037 217 N054.36.43.340 W005.52.47.140 N054.37.29.480 W005.51.51.950 EGAC
+
+[SID]
+EDDM SID 26L BIBAGxS                     N048.20.25.315 E011.44.49.465 N048.20.15.608 E011.42.33.951
+                                         N048.20.15.608 E011.42.33.951 N048.17.15.248 E011.42.28.821
+                                         N048.17.15.248 E011.42.28.821 N048.10.49.418 E011.48.59.529
+                                         N048.10.49.418 E011.48.59.529 N048.13.54.868 E012.33.55.821
+                                         N048.13.54.868 E012.33.55.821 N048.23.49.380 E012.44.59.211
+
+EDDN SID 28 BOLSIxG                      N049.30.02.914 E011.03.23.507 N049.30.47.941 E010.55.42.060
+                                         N049.30.47.941 E010.55.42.060 N049.27.44.369 E010.45.45.219
+                                         N049.27.44.369 E010.45.45.219 N049.13.54.559 E010.45.30.628
+
+[STAR]
+EDDM TRAN RNP26R LANDU26                 N048.35.46.899 E012.16.26.140 N048.32.16.501 E011.30.05.529 colour_APP
+                                         N048.32.16.501 E011.30.05.529 N048.25.44.061 E011.31.15.931 colour_APP
+                                         N048.25.44.061 E011.31.15.931 N048.29.36.319 E012.22.42.409 colour_APP
+                                         N048.29.36.319 E012.22.42.409 N048.30.47.361 E012.37.38.952 colour_APP
+
+EDDN TRAN ILS10 DN430                    N049.33.11.289 E010.30.33.379 N049.32.37.168 E010.36.38.149 colour_APP
+                                         N049.32.37.168 E010.36.38.149 N049.32.02.731 E010.42.42.681 colour_APP
+
+EDQD STAR ALL LONLIxZ                    N050.04.29.060 E011.13.34.989 N049.53.50.819 E011.24.28.540
+
+[ARTCC HIGH]
+EDJA_ILR_APP                             N048.10.28.000 E009.34.15.000 N048.18.09.000 E009.55.25.000
+                                         N048.10.28.000 E009.34.15.000 N048.10.00.000 E009.33.00.000
+                                         N047.58.59.000 E010.50.38.000 N048.14.12.000 E010.25.42.000
+                                         N048.14.12.000 E010.25.42.000 N048.18.09.000 E009.55.25.000
+                                         N047.58.59.000 E010.50.38.000 N047.52.03.000 E010.28.00.000
+                                         N047.52.03.000 E010.28.00.000 N047.50.30.000 E010.23.00.000
+                                         N047.50.30.000 E010.23.00.000 N047.49.05.000 E009.58.21.000
+                                         N047.53.53.000 E009.50.08.000 N047.48.55.000 E009.54.18.000
+                                         N047.48.55.000 E009.54.18.000 N047.49.05.000 E009.58.21.000
+                                         N047.53.53.000 E009.50.08.000 N047.53.24.000 E009.33.00.000
+                                         N047.53.24.000 E009.33.00.000 N047.58.24.000 E009.33.00.000
+                                         N047.58.24.000 E009.33.00.000 N048.10.00.000 E009.33.00.000
+
+Release line EDMM ARBAX Window           N049.26.33.000 E012.52.22.000 N049.35.18.000 E013.00.24.000 colour_Releaseline
+                                         N049.35.18.000 E013.00.24.000 N049.27.45.000 E013.17.13.000 colour_Releaseline
+                                         N049.27.45.000 E013.17.13.000 N049.12.42.000 E013.13.14.000 colour_Releaseline
+
+[ARTCC]
+EDMM_ALB_CTR                             N049.08.17.000 E011.07.57.000 N049.10.00.000 E011.58.00.000
+                                         N048.40.03.000 E011.47.39.000 N049.10.00.000 E011.58.00.000
+                                         N048.40.03.000 E011.47.39.000 N048.40.04.000 E011.30.42.000
+                                         N048.40.04.000 E011.30.42.000 N048.40.04.000 E011.19.15.000
+                                         N048.40.04.000 E011.19.15.000 N049.07.10.000 E010.40.25.000
+                                         N049.07.10.000 E010.40.25.000 N049.08.17.000 E011.07.57.000
+                                         N049.07.10.000 E010.40.25.000 N049.10.43.000 E010.35.16.000
+                                         N049.26.04.000 E011.49.08.000 N049.26.30.000 E010.58.00.000
+                                         N049.10.43.000 E010.35.16.000 N049.26.30.000 E010.58.00.000
+                                         N049.26.30.000 E010.58.00.000 N049.39.17.000 E010.45.56.000
+                                         N049.10.43.000 E010.35.16.000 N049.17.00.000 E010.27.30.000
+                                         N049.17.00.000 E010.27.30.000 N049.23.54.000 E010.21.22.000
+                                         N049.23.54.000 E010.21.22.000 N049.30.40.000 E010.30.12.000
+                                         N049.30.40.000 E010.30.12.000 N049.39.17.000 E010.45.56.000
+                                         N049.10.00.000 E011.58.00.000 N049.26.04.000 E011.49.08.000
+
+EDMM_WLD_CTR                             N048.40.00.000 E010.58.00.000 N048.40.10.000 E011.11.00.000
+                                         N048.40.10.000 E011.11.00.000 N048.40.04.000 E011.19.15.000
+                                         N049.01.02.000 E010.15.27.000 N049.06.40.000 E010.28.45.000
+                                         N049.06.40.000 E010.28.45.000 N049.10.43.000 E010.35.16.000
+                                         N048.40.04.000 E011.19.15.000 N049.07.10.000 E010.40.25.000
+                                         N049.07.10.000 E010.40.25.000 N049.10.43.000 E010.35.16.000
+                                         N048.37.28.000 E010.54.16.000 N049.01.02.000 E010.15.27.000
+                                         N048.37.28.000 E010.54.16.000 N048.40.00.000 E010.58.00.000
+
+[ARTCC LOW]
+RMZ EDMS                                 N048.57.40.000 E012.23.34.000 N048.56.22.000 E012.39.38.000 colour_RMZ
+                                         N048.56.22.000 E012.39.38.000 N048.50.25.000 E012.38.30.000 colour_RMZ
+                                         N048.50.25.000 E012.38.30.000 N048.51.43.000 E012.22.28.000 colour_RMZ
+                                         N048.51.43.000 E012.22.28.000 N048.57.40.000 E012.23.34.000 colour_RMZ
+
+RMZ EDNX                                 N048.16.27.000 E011.27.21.000 N048.17.12.000 E011.32.05.000 colour_RMZ
+                                         N048.17.12.000 E011.32.05.000 N048.16.25.000 E011.32.09.000 colour_RMZ
+                                         N048.16.25.000 E011.32.09.000 N048.16.54.000 E011.38.27.000 colour_RMZ
+                                         N048.16.54.000 E011.38.27.000 N048.15.17.000 E011.40.25.000 colour_RMZ
+                                         N048.15.17.000 E011.40.25.000 N048.14.28.000 E011.40.40.000 colour_RMZ
+                                         N048.14.28.000 E011.40.40.000 N048.12.14.000 E011.39.45.000 colour_RMZ
+                                         N048.12.14.000 E011.39.45.000 N048.10.38.000 E011.29.22.000 colour_RMZ
+                                         N048.10.38.000 E011.29.22.000 N048.16.27.000 E011.27.21.000 colour_RMZ
+
+[GEO]
+EDDN Groundlayout Holding Points         N049.29.58.736 E011.03.33.028 N049.29.58.942 E011.03.34.353 colour_Stopbar
+                                         N049.29.56.786 E011.03.52.659 N049.29.57.006 E011.03.54.022 colour_Stopbar
+
+EDQC Groundlayout                        N050.15.52.011 E010.59.29.553 N050.15.52.239 E010.59.29.566
+
+EDQC Groundlayout                        N050.15.52.011 E010.59.29.553 N050.15.52.239 E010.59.29.566 colour_Stopbar
+                                         N050.15.39.345 E011.00.04.860 N050.15.39.411 E011.00.05.139 colour_Stopbar
+                                         N050.15.39.345 E011.00.04.860 N050.15.39.411 E011.00.05.139
+                                         RAVSA RAVSA LCE13 LCE13 geoDefault
+
+HIGHWAYS LOVV                            N048.12.09.100 E016.13.16.700 N048.11.27.100 E016.12.10.100 COLOR_Landmark2
+                                         N050.15.39.345 E011.00.04.860 N050.15.39.411 E011.00.05.139 colour_Stopbar
+
+[REGIONS]
+REGIONNAME EDDM Groundlayout
+colour_Stopbar             N048.21.53.621 E011.48.32.152
+                           N048.21.54.514 E011.48.32.715
+                           N048.21.54.527 E011.48.32.571
+                           N048.21.53.676 E011.48.32.042
+REGIONNAME EDMO Groundlayout
+colour_HardSurface1        N048.04.25.470 E011.16.20.093
+                           N048.04.24.509 E011.16.21.717
+                           N048.05.20.677 E011.17.38.446
+                           N048.05.21.638 E011.17.36.829
+REGIONNAME Surrounding Grass
+grass                      N051.11.37.165 E002.51.07.153
+                           N051.11.38.619 E002.51.08.463
+                           N051.11.39.660 E002.51.10.008
+
+[HIGH AIRWAY]
+B73        N054.54.46.000 E018.57.29.998 N055.36.12.999 E019.50.17.901
+B74        N055.12.05.000 E019.38.03.001 N055.36.12.999 E019.50.17.901
+B74        N054.38.16.000 E019.21.20.001 N055.12.05.000 E019.38.03.001
+B75        ARMUT ARMUT VEMUT VEMUT
+B76        ARMUT ARMUT RTT RTT
+
+[LOW AIRWAY]
+A361       N048.56.21.001 E000.57.11.001 N048.47.26.199 E000.31.49.000
+A361       N049.01.42.700 E001.12.50.601 N048.56.21.001 E000.57.11.001
+A4         N048.37.03.248 E017.32.28.201 N048.42.56.998 E017.23.09.999
+A4         N048.17.25.569 E018.03.02.300 N048.37.03.248 E017.32.28.201
+A4         N048.42.56.998 E017.23.09.999 N048.51.11.520 E017.10.04.238
+A5         RTT RTT NUB NUB
+";
+        assert_eq_sorted!(expected_generated, sct_generated);
     }
 
     #[test]

--- a/src/topsky/map/mod.rs
+++ b/src/topsky/map/mod.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 
 use crate::{
     adaptation::{colours::Colour, line_styles::LineStyle, maps::active::Active, Alignment},
-    read_to_string, DegMinSec, FromDegMinSec, Location,
+    read_to_string, DegMinSec, DegMinSecExt as _, Location,
 };
 
 use super::{
@@ -37,11 +37,11 @@ impl CoordinatePart {
                     .next()
                     .unwrap()
                     .as_str()
-                    .parse::<f64>()
+                    .parse::<i16>()
                     .unwrap()
                     * match hemi {
-                        "N" | "n" | "E" | "e" => 1.0,
-                        "S" | "s" | "W" | "w" => -1.0,
+                        "N" | "n" | "E" | "e" => 1,
+                        "S" | "s" | "W" | "w" => -1,
                         _ => unreachable!("{hemi} is not a hemisphere"),
                     };
                 let min = sct_coord_part.next().unwrap().as_str().parse().unwrap();


### PR DESCRIPTION

<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/blip-radar/vatsim-parser/tree/main) ([9437057](https://github.com/blip-radar/vatsim-parser/commit/9437057748bfae8c8255a14c58f49e1ae08ccb38)) | [#136](https://github.com/blip-radar/vatsim-parser/pull/136) ([88b02fd](https://github.com/blip-radar/vatsim-parser/commit/88b02fdbb2aec5f3875972a1c5b923ad854bf3c2)) |  +/-  |
|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                                  50.7% |                                                                                                                                                                 54.7% | +3.9% |
| **Test Execution Time** |                                                                                                                                                                  2m12s |                                                                                                                                                                 2m22s |  +10s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (9437057) | #136 (88b02fd) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          50.7% |          54.7% | +3.9% |
  |   Files             |             27 |             27 |     0 |
  |   Lines             |           2138 |           2385 |  +247 |
+ |   Covered           |           1086 |           1305 |  +219 |
- | Test Execution Time |          2m12s |          2m22s |  +10s |
```

</details>


### Code coverage of files in pull request scope (61.8% → 68.1%)

|                                                                        Files                                                                         | Coverage |  +/-   |
|------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|-------:|
| [src/adaptation/colours.rs](https://github.com/blip-radar/vatsim-parser/blob/b71f11df2b4a8b60235e83559ca5b54d77863172/src%2Fadaptation%2Fcolours.rs) | 8.7%     | +2.0%  |
| [src/ese.rs](https://github.com/blip-radar/vatsim-parser/blob/b71f11df2b4a8b60235e83559ca5b54d77863172/src%2Fese.rs)                                 | 85.2%    | 0.0%   |
| [src/lib.rs](https://github.com/blip-radar/vatsim-parser/blob/b71f11df2b4a8b60235e83559ca5b54d77863172/src%2Flib.rs)                                 | 70.0%    | +22.0% |
| [src/sct.rs](https://github.com/blip-radar/vatsim-parser/blob/b71f11df2b4a8b60235e83559ca5b54d77863172/src%2Fsct.rs)                                 | 88.1%    | +0.7%  |
| [src/topsky/map/mod.rs](https://github.com/blip-radar/vatsim-parser/blob/b71f11df2b4a8b60235e83559ca5b54d77863172/src%2Ftopsky%2Fmap%2Fmod.rs)       | 25.7%    | 0.0%   |

---
Reported by octocov
<!-- octocov -->
